### PR TITLE
feat(app): (#2) (config) ; Add MySQL and JPA/Hibernate config

### DIFF
--- a/rest/bin/main/application.properties
+++ b/rest/bin/main/application.properties
@@ -1,1 +1,12 @@
 spring.application.name=rest
+
+# MySQL Database Configuration
+spring.datasource.url=jdbc:mysql://localhost:3306/your_database_name
+spring.datasource.username=root
+spring.datasource.password=
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA/Hibernate Configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -1,1 +1,12 @@
 spring.application.name=rest
+
+# MySQL Database Configuration
+spring.datasource.url=jdbc:mysql://localhost:3306/your_database_name
+spring.datasource.username=root
+spring.datasource.password=
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA/Hibernate Configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
This pull request introduces database configuration for a MySQL database and JPA/Hibernate settings in the `application.properties` file. These changes enable the application to connect to a MySQL database and configure Hibernate for ORM functionality.

### Database Configuration:
* Added MySQL database connection properties, including `spring.datasource.url`, `spring.datasource.username`, `spring.datasource.password`, and `spring.datasource.driver-class-name`.

### JPA/Hibernate Configuration:
* Configured Hibernate with `spring.jpa.hibernate.ddl-auto`, `spring.jpa.show-sql`, and `spring.jpa.properties.hibernate.dialect` properties to manage schema updates, enable SQL query logging, and specify the MySQL dialect.