### PR TITLE
fix (tools):  update hibernate dialect to MYSQL8Dialect (#3)

### DIFF
--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -9,4 +9,5 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # JPA/Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+# spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
This pull request updates the Hibernate dialect configuration in the `application.properties` file to use the MySQL 8 dialect, ensuring compatibility with MySQL 8 features.

* [`rest/src/main/resources/application.properties`](diffhunk://#diff-8810e68cdbcdbe089818a1288d19b60c45624e4483765806e27c9b6e07d3290fL12-R13): Commented out the old `MySQLDialect` and replaced it with `MySQL8Dialect` for the `spring.jpa.properties.hibernate.dialect` property.