### PR TITLE
add debugging output; biar gampang cari eror

### DIFF
--- a/src/main/java/com/ruangkerja/rest/controller/JobController.java
+++ b/src/main/java/com/ruangkerja/rest/controller/JobController.java
@@ -100,6 +100,7 @@ public class JobController {
             return ResponseEntity.ok(response);
             
         } catch (Exception e) {
+            e.printStackTrace(); // Add this for debugging
             Map<String, Object> response = new HashMap<>();
             response.put("success", false);
             response.put("message", "Failed to create job: " + e.getMessage());


### PR DESCRIPTION
This pull request includes a minor debugging enhancement to the `createJob` method in the `JobController` class. The change adds a line to print the stack trace of exceptions for debugging purposes.

* [`src/main/java/com/ruangkerja/rest/controller/JobController.java`](diffhunk://#diff-f37bf8b640c8b4054e27b1d87b7fc0827754817bb785bb2d9d12b96c57f46b9bR103): Added `e.printStackTrace()` in the `catch` block of the `createJob` method to assist in debugging by logging the exception details.