### PR TITLE
test

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,12 @@
-name: CI - ruangkerja
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: ruangkerja
 
 on:
   push:
@@ -7,42 +15,17 @@ on:
     branches: [ "main" ]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Run tests
-        run: mvn test
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: target/surefire-reports/
-
   build:
+
     runs-on: ubuntu-latest
-    needs: test
+
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Build with Maven
-        run: mvn clean compile
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml


### PR DESCRIPTION
This pull request updates the `.github/workflows/maven.yml` file to streamline the CI workflow for a Java project using Maven. The most notable changes include simplifying the workflow structure, removing the `test` job, and enhancing the `build` job to include packaging with Maven.

### Workflow structure updates:

* Removed the `test` job entirely, along with its associated steps for running tests and uploading test results. The workflow now focuses solely on the `build` job.

### Build job enhancements:

* Updated the `Build with Maven` step to use the `mvn -B package --file pom.xml` command, enabling batch mode for cleaner logs and specifying the `pom.xml` file explicitly.

### Documentation improvements:

* Added comments at the top of the workflow file to explain its purpose, reference GitHub documentation, and clarify that it uses third-party actions.